### PR TITLE
fix: detect commands on native Windows

### DIFF
--- a/.github/workflows/build-publish-zellij-plugin.yaml
+++ b/.github/workflows/build-publish-zellij-plugin.yaml
@@ -27,13 +27,20 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@v1
         with:
-          profile: minimal
-          override: true
+          components: rustfmt
           toolchain: '1.83.0'
           target: wasm32-wasip1
 
+      - name: Check formatting
+        run: cargo fmt -- --check
+
+      - name: Run tests
+        run: |
+          rustc --test src/command.rs -o /tmp/zellij-autolock-command-tests
+          /tmp/zellij-autolock-command-tests
+
       - name: Build release binary
-        run: cargo build --release
+        run: cargo build --locked --release
 
       - if: >
           github.ref_type == 'tag'

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,0 +1,94 @@
+pub(crate) fn running_command_executable(running_command: &str) -> String {
+    let command = running_command.trim();
+    let lowercase = command.to_ascii_lowercase();
+
+    // Native Windows reports an unquoted full executable path followed by
+    // arguments, even when the path contains spaces. The .exe suffix is the
+    // only reliable boundary in that representation.
+    let executable = if command.starts_with('"') {
+        let end = command[1..]
+            .find('"')
+            .map(|index| index + 1)
+            .unwrap_or(command.len());
+        &lowercase[1..end]
+    } else if let Some(end) = lowercase.match_indices(".exe").find_map(|(start, suffix)| {
+        let end = start + suffix.len();
+        let is_boundary = lowercase[end..]
+            .chars()
+            .next()
+            .map_or(true, |character| character.is_whitespace());
+        is_boundary.then_some(end)
+    }) {
+        &lowercase[..end]
+    } else {
+        lowercase.split_whitespace().next().unwrap_or("")
+    };
+
+    let basename = executable
+        .rsplit(|character| character == '/' || character == '\\')
+        .next()
+        .unwrap_or("");
+
+    basename
+        .strip_suffix(".exe")
+        .unwrap_or(basename)
+        .to_string()
+}
+
+pub(crate) fn is_trigger_command(running_command: &str, triggers: &[String]) -> bool {
+    let executable = running_command_executable(running_command);
+
+    triggers.iter().any(|trigger| {
+        trigger.eq_ignore_ascii_case(running_command)
+            || (!executable.is_empty() && running_command_executable(trigger) == executable)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_trigger_command, running_command_executable};
+
+    #[test]
+    fn extracts_unix_executables() {
+        assert_eq!(running_command_executable("/usr/bin/vim README.md"), "vim");
+        assert_eq!(
+            running_command_executable(r#""/opt/Vim Builds/vim" README.md"#),
+            "vim"
+        );
+        assert_eq!(running_command_executable("nvim"), "nvim");
+    }
+
+    #[test]
+    fn extracts_windows_executables_with_spaces_and_arguments() {
+        assert_eq!(
+            running_command_executable(r"C:\Program Files\Vim\vim92\vim.EXE -Nu NONE README.md"),
+            "vim"
+        );
+        assert_eq!(
+            running_command_executable(r#""C:\Tools\Neovim\bin\nvim.exe" README.md"#),
+            "nvim"
+        );
+        assert_eq!(
+            running_command_executable(r"C:\Tools.exe-dir\Vim\vim.EXE README.md"),
+            "vim"
+        );
+    }
+
+    #[test]
+    fn matches_normalized_executables_against_triggers() {
+        let triggers = vec!["vim".to_string(), "nvim.exe".to_string()];
+
+        assert!(is_trigger_command(
+            r"C:\Program Files\Vim\vim92\vim.EXE README.md",
+            &triggers
+        ));
+        assert!(is_trigger_command(
+            r#""C:\Tools\Neovim\bin\NVIM.exe" README.md"#,
+            &triggers
+        ));
+        assert!(!is_trigger_command(
+            r"C:\Program Files\PowerShell\7\pwsh.EXE",
+            &triggers
+        ));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,6 @@
+mod command;
+
+use command::{is_trigger_command, running_command_executable};
 use std::collections::BTreeMap;
 use zellij_tile::prelude::*;
 use zellij_tile::shim::list_clients;
@@ -120,15 +123,10 @@ impl ZellijPlugin for State {
                         let mut is_trigger_cmd = false;
 
                         if running_command != "N/A" {
-                            let running_command_exe =
-                                running_command.split_whitespace().collect::<Vec<_>>()[0]
-                                    .split('/')
-                                    .last()
-                                    .unwrap_or("")
-                                    .to_string();
+                            let running_command_exe = running_command_executable(&running_command);
 
-                            is_trigger_cmd = self.lock_trigger_cmds.contains(&running_command)
-                                || self.lock_trigger_cmds.contains(&running_command_exe);
+                            is_trigger_cmd =
+                                is_trigger_command(&running_command, &self.lock_trigger_cmds);
 
                             if self.print_to_log {
                                 eprintln!(


### PR DESCRIPTION
## Summary

- Normalize the running executable before comparing it with configured triggers.
- Parse native Windows paths containing spaces, arguments, backslash separators, and case-insensitive .exe suffixes.
- Add standalone Windows and Unix parser tests and run them before release builds.

## Why

Native Windows Zellij reports commands such as C:\Program Files\Vim\vim92\vim.EXE README.md. Version 0.2.2 splits on whitespace and then only on forward slashes, so it does not recognize Vim and never enters Locked mode.

## Validation

- Local parser tests: 3 passed.
- Local optimized wasm32-wasip1 build passed.
- Fork formatting, parser tests, and WASM build passed in Actions run 33260540690.